### PR TITLE
Allow users to configure plaintext vs. emoji alt tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Default configuration integrates with Rails, but you can change it with an initi
 # config/initializers/emoji.rb
 Emoji.asset_host = "emoji.cdn.com"
 Emoji.asset_path = '/assets/emoji'
+Emoji.use_plaintext_alt_tags = true
 ```
 
 String Helper Methods:

--- a/lib/emoji/railtie.rb
+++ b/lib/emoji/railtie.rb
@@ -6,6 +6,7 @@ module Emoji
     initializer "emoji.defaults" do
       Emoji.asset_host = ActionController::Base.asset_host
       Emoji.asset_path = '/assets/emoji'
+      Emoji.use_plaintext_alt_tags = false
     end
 
     rake_tasks do

--- a/test/emoji_test.rb
+++ b/test/emoji_test.rb
@@ -39,6 +39,18 @@ describe Emoji do
     end
   end
 
+  describe "use_plaintext_alt_tags" do
+    it 'should default to false' do
+      refute Emoji.use_plaintext_alt_tags
+    end
+
+    it 'should be configurable' do
+      with_emoji_config(:use_plaintext_alt_tags, true) do
+        assert Emoji.use_plaintext_alt_tags
+      end
+    end
+  end
+
   describe "replace_unicode_moji_with_images" do
     it 'should return original string without emoji' do
       assert_equal "foo", Emoji.replace_unicode_moji_with_images('foo')
@@ -53,6 +65,14 @@ describe Emoji do
       base_string = "I ❤ Emoji"
       replaced_string = Emoji.replace_unicode_moji_with_images(base_string)
       assert_equal "I <img alt=\"❤\" class=\"emoji\" src=\"http://localhost:3000/heart.png\"> Emoji", replaced_string
+    end
+
+    it 'should use plaintext alt tags if configured to do so' do
+      with_emoji_config(:use_plaintext_alt_tags, true) do
+        base_string = "I ❤ Emoji"
+        replaced_string = Emoji.replace_unicode_moji_with_images(base_string)
+        assert_equal "I <img alt=\"heart\" class=\"emoji\" src=\"http://localhost:3000/heart.png\"> Emoji", replaced_string
+      end
     end
 
     it 'should handle nil string' do


### PR DESCRIPTION
Allows the user to configure the emoji img tag to use plaintext for its alt text instead of the emoji itself.

Specific use case: Users who wish to store the resulting tag to a database that is not configured to support emoji encoding.